### PR TITLE
Adding 5 axis raster scanning for L-PBF

### DIFF
--- a/template_input.yaml
+++ b/template_input.yaml
@@ -8,7 +8,9 @@ layer_groups:
       base_speed:  0.0       # contour speed in mm/s
       power: 0.0             # power in mW
     interlayer_dwell:  0.0   # dwell time in s. only relevant if dwell is true
-    
+
+5_AXIS: "true"               # Used for adding laser angle for L-PBF
+chamber_height: 35           # chamber height used for determining laser angle
 interval: 1                  # interpolated points between all points from gcode
 layer_height: 0.0            # layer height in mm
 last_layer_height_change: 0  # last layer height change in mm

--- a/template_input_multi_group.yaml
+++ b/template_input_multi_group.yaml
@@ -20,7 +20,9 @@ layer_groups:
       output_speed:  0.0     # contour speed used with layer group in mm/s
       power: 0.0             # power in mW
     interlayer_dwell: 0.0    # dwell time in s. only relevant if dwell is true
-    
+
+5_AXIS: "true"               # Used for adding laser angle for L-PBF
+chamber_height: 35           # chamber height used for determining laser angle  
 interval: 1                  # interpolated points between all points from gcode
 layer_height: 0.0            # layer height in mm
 last_layer_height_change: 0  # last layer height change in mm


### PR DESCRIPTION
The purpose of this feature is to allow for AMPES to account for angle of incidence of the laser on the part during scanning